### PR TITLE
:sparkles: Focus on commit editor after the insertion

### DIFF
--- a/lib/gitmoji-atom.js
+++ b/lib/gitmoji-atom.js
@@ -109,6 +109,7 @@ module.exports = {
                 `Inserted '${valueToSubmit}' to commit editor!`
               );
             }
+            commitEditor.element.focus();
           } else {
             writeToClipboard(valueToSubmit);
           }


### PR DESCRIPTION
Just a minor UX improvement. Would improve the commit speed ⚡ .