### PR TITLE
:bug: Reset search bar correctly

### DIFF
--- a/lib/gitmoji-atom.js
+++ b/lib/gitmoji-atom.js
@@ -136,7 +136,7 @@ module.exports = {
           break;
       }
       if (atom.config.get("gitmoji-atom.resetSearchBar") == true) {
-        this.gitmojiAtomView.query = "";
+        this.gitmojiAtomView.reset();
       }
     }
     this.modalPanel.hide();


### PR DESCRIPTION
Set `.query` to `""` would not reset the search bar correctly. Calling the `.reset()` to do so.